### PR TITLE
Add amazon linux support

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'package@datadoghq.com'
 license          'Apache 2.0'
 description      'Installs/Configures datadog components'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.10.2'
+version          '2.10.3'
 source_url       'https://github.com/DataDog/chef-datadog' if respond_to? :source_url
 issues_url       'https://github.com/DataDog/chef-datadog/issues' if respond_to? :issues_url
 

--- a/recipes/_install-linux.rb
+++ b/recipes/_install-linux.rb
@@ -23,7 +23,7 @@ include_recipe 'datadog::repository' if node['datadog']['installrepo']
 dd_agent_version =
   if node['datadog']['agent_version'].respond_to?(:each_pair)
     case node['platform_family']
-    when 'rhel', 'fedora'
+    when 'rhel', 'fedora', 'amazon'
       node['datadog']['agent_version']['rhel']
     else
       node['datadog']['agent_version'][node['platform_family']]
@@ -60,7 +60,7 @@ else
       action node['datadog']['agent_package_action'] # default is :install
       options '--force-yes' if node['datadog']['agent_allow_downgrade']
     end
-  when 'rhel', 'fedora'
+  when 'rhel', 'fedora', 'amazon'
     yum_package 'datadog-agent' do
       version dd_agent_version
       retries package_retries unless package_retries.nil?

--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -42,7 +42,7 @@ when 'debian'
     action :add
   end
 
-when 'rhel', 'fedora'
+when 'rhel', 'fedora', 'amazon'
   include_recipe 'yum'
 
   # Import new RPM key


### PR DESCRIPTION
There is a bug in the dd-agent/dd-handler recipe for Amazon Linux as shown below:

```Shell
* service[datadog-agent]: Service is not known to chkconfig.
    ================================================================================
    Error executing action `enable` on resource 'service[datadog-agent]'
    ================================================================================

    Chef::Exceptions::Service
    -------------------------
    service[datadog-agent]: Service is not known to chkconfig.

    Resource Declaration:
    ---------------------
    # In /var/chef/cache/cookbooks/datadog/recipes/dd-agent.rb

    101: service 'datadog-agent' do
    102:   service_name node['datadog']['agent_name']
    103:   action [agent_enable, agent_start]
    104:   if is_windows
    105:     supports :restart => true, :start => true, :stop => true
    106:   else
    107:     supports :restart => true, :status => true, :start => true, :stop => true
    108:   end
    109:   subscribes :restart, "template[#{agent_config_file}]", :delayed unless node['datadog']['agent_start'] == false

    Compiled Resource:
    ------------------
    # Declared in /var/chef/cache/cookbooks/datadog/recipes/dd-agent.rb:101:in `from_file'

    service("datadog-agent") do
      action [:enable, :start]
      default_guard_interpreter :default
      service_name "datadog-agent"
      enabled nil
      running nil
      masked nil
      pattern "datadog-agent"
      declared_type :service
      cookbook_name "datadog"
      recipe_name "dd-agent"
      supports {:restart=>true, :status=>true, :start=>true, :stop=>true}
    end

System Info:
    ------------
    chef_version=13.3.42
    platform=amazon
    platform_version=2017.03
    ruby=ruby 2.4.1p111 (2017-03-22 revision 58053) [x86_64-linux]
    program_name=chef-client worker: ppid=7552;start=03:41:56;
    executable=/opt/chef/bin/chef-client
```
There is a step that installs the agent from the official datadog repo which is determined using a case structure based on the ```node['platform_family']```. However, ```amazon``` isn't set anywhere. 

After some digging into it I found that the installation via shell script provided at Datadog agent installation considers the same repo for RHEL, Fedora, CentOs and Amazon Linux as shown here: https://github.com/DataDog/dd-agent/blob/master/packaging/datadog-agent/source/install_agent.sh#L76-L77

Now it's running fine 👍 

```Shell
......

Recipe: datadog::_install-linux
  * yum_package[datadog-agent-base] action remove (up to date)
  * yum_package[datadog-agent] action install
    - install version 5.17.0-1 of package datadog-agent
Recipe: datadog::dd-agent
  * directory[/etc/dd-agent] action create
    - change group from 'dd-agent' to 'root'
  * template[/etc/dd-agent/datadog.conf] action create
    - change group from 'dd-agent' to 'root'
  * service[datadog-agent] action enable (up to date)
  * service[datadog-agent] action start
    - start service service[datadog-agent]
Recipe: datadog::dd-handler
  * chef_gem[chef-handler-datadog] action install (up to date)
  * chef_handler[Chef::Handler::Datadog] action nothing (skipped due to action :nothing)
Recipe: datadog::dd-agent
  * service[datadog-agent] action restart
    - restart service service[datadog-agent]

```